### PR TITLE
Added python-dotenv to make running locally easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Constantine can run locally or from GitHub Actions.
 
 Set environment variables `BLUESKY_USER` and `BLUESKY_APP_PASSWORD`.
 
+Alternatively, create a `.env` file and set variables there:
+
+```Dotenv
+BLUESKY_USER=<your user/email>
+BLUESKY_APP_PASSWORD=<your password>
+```
+
 Example:
 
 ```

--- a/constantine.py
+++ b/constantine.py
@@ -7,6 +7,10 @@ from json import JSONDecodeError
 
 import requests
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 MAX_GET_AUTHOR_FEED_LIMIT = 100
 
 BLESSED_HELLTHREAD = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.28.2
 black==23.3.0
 ruff==0.0.262
-python-dotenv=1.0.0
+python-dotenv==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.28.2
 black==23.3.0
 ruff==0.0.262
+python-dotenv=1.0.0


### PR DESCRIPTION
Added support for python-dotenv to keep creds in a local .env file because I always forget to export.